### PR TITLE
Add coverage support

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [workspace]
 resolver = "3"
-members = ["js-bindgen", "js-sys", "test", "web-sys"]
+members = ["cov", "js-bindgen", "js-sys", "test", "web-sys"]
 
 [workspace.package]
 edition = "2024"
@@ -23,12 +23,14 @@ include = [
 
 [workspace.dependencies]
 js-bindgen = { path = "js-bindgen" }
+js-bindgen-cov = { path = "cov" }
 js-bindgen-macro = { path = "../host/macro" }
 js-bindgen-test = { path = "test" }
 js-bindgen-test-macro = { path = "../host/test-macro" }
 js-sys = { path = "js-sys" }
 js-sys-macro = { path = "../host/js-sys-macro" }
 mini-alloc = "1"
+minicov = "0.3.8"
 paste = "1"
 web-sys = { path = "web-sys" }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -69,6 +69,9 @@ name = "basic"
 mini-alloc = { workspace = true }
 web-sys = { workspace = true }
 
+[target.'cfg(js_bindgen_cov)'.dev-dependencies]
+js-bindgen-cov = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/client/cov/Cargo.toml
+++ b/client/cov/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "js-bindgen-cov"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+include.workspace = true
+
+[lib]
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+js-sys = { workspace = true, features = ["macro"] }
+minicov = { workspace = true }
+
+[lints]
+workspace = true

--- a/client/cov/src/lib.rs
+++ b/client/cov/src/lib.rs
@@ -1,0 +1,114 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use js_sys::{JsArray, JsString, js_sys};
+
+#[js_sys]
+extern "js-sys" {
+	#[js_sys(js_import)]
+	fn pid() -> u32;
+	#[js_sys(js_import)]
+	fn tmpdir() -> JsString;
+	#[js_sys(js_import)]
+	fn llvm_profile_file() -> JsString;
+	#[js_sys(js_import)]
+	fn next_profraw() -> JsArray<u8>;
+	#[js_sys(js_import)]
+	fn record_profraw(path: &JsString, buf: &JsArray<u8>);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn set_profraw() {
+	if !minicov::coverage_enabled() {
+		return;
+	}
+
+	merge_profraw();
+
+	let mut cov = Vec::new();
+	// SAFETY: this function is not thread-safe, but our whole test runner is
+	// running single-threaded.
+	unsafe {
+		minicov::capture_coverage(&mut cov).unwrap();
+	}
+
+	let env = llvm_profile_file().to_string();
+	let path = coverage_path(
+		(!env.is_empty()).then_some(env).as_deref(),
+		pid(),
+		&tmpdir().to_string(),
+		minicov::module_signature(),
+	);
+
+	record_profraw(
+		&JsString::from(path.as_str()),
+		&JsArray::<u8>::from(cov.as_slice()),
+	);
+}
+
+fn merge_profraw() {
+	let profraw = next_profraw();
+
+	if profraw.length() == 0 {
+		return;
+	}
+
+	let mut data = vec![0; profraw.length() as usize];
+
+	if profraw.to_slice(&mut data).is_ok() {
+		// SAFETY: this function is not thread-safe, but our whole test runner is
+		// running single-threaded.
+		unsafe {
+			let _ = minicov::merge_coverage(&data);
+		}
+	}
+}
+
+fn coverage_path(env: Option<&str>, pid: u32, tmpdir: &str, module_signature: u64) -> String {
+	let env = env.unwrap_or("default_%m_%p.profraw");
+
+	let mut path = String::new();
+	let mut chars = env.chars().enumerate().peekable();
+
+	while let Some((index, char)) = chars.next() {
+		if char != '%' {
+			path.push(char);
+			continue;
+		}
+
+		if chars.next_if(|(_, c)| *c == 'p').is_some() {
+			path.push_str(&pid.to_string());
+		} else if chars.next_if(|(_, c)| *c == 'h').is_some() {
+			path.push_str("jbgcov");
+		} else if chars.next_if(|(_, c)| *c == 't').is_some() {
+			path.push_str(tmpdir);
+		} else {
+			let mut last_index = index;
+
+			loop {
+				if let Some((index, _)) = chars.next_if(|(_, c)| c.is_ascii_digit()) {
+					last_index = index;
+				} else if chars.next_if(|(_, c)| *c == 'm').is_some() {
+					path.push_str(&module_signature.to_string());
+					path.push_str("_0");
+					break;
+				} else {
+					path.push_str(&env[index..=last_index]);
+					break;
+				}
+			}
+		}
+	}
+
+	path
+}
+
+#[macro_export]
+macro_rules! ensure_linked {
+	() => {};
+}

--- a/client/examples/basic.rs
+++ b/client/examples/basic.rs
@@ -11,6 +11,9 @@ use mini_alloc::MiniAlloc;
 use web_sys::console;
 use web_sys::js_sys::JsString;
 
+#[cfg(js_bindgen_cov)]
+js_bindgen_cov::ensure_linked!();
+
 #[panic_handler]
 fn panic(_: &panic::PanicInfo<'_>) -> ! {
 	wasm::unreachable();

--- a/client/js-sys/src/array/array.gen.rs
+++ b/client/js-sys/src/array/array.gen.rs
@@ -364,3 +364,125 @@ pub(super) unsafe fn array_u32_encode(
 		array_u32_encode(Input::into_raw(array), Input::into_raw(ptr), Input::into_raw(len))
 	})
 }
+
+pub(super) unsafe fn array_u8_decode(array: PtrConst<u8>, len: PtrLength<u8>) -> JsArray<u8> {
+	js_bindgen::unsafe_global_wat! {
+		"(import \"js_sys\" \"array_u8_decode\" (func $js_sys.import.array_u8_decode (@sym (name \"js_sys.import.array_u8_decode\")) (param {} {}) (result {}))){}",
+		"(func $js_sys.array_u8_decode (@sym) (param {}) (param $array {}) (param $len {}) (result {})",
+		"  local.get $array{}", "  local.get $len{}",
+		"  call $js_sys.import.array_u8_decode (@reloc){}", ")", interpolate
+		r#macro::wat_input_import_type:: < PtrConst < u8 > > (), interpolate
+		r#macro::wat_input_import_type:: < PtrLength < u8 > > (), interpolate
+		r#macro::wat_output_import_type:: < JsArray < u8 > > (), interpolate
+		r#macro::wat_imports!((PtrConst < u8 >, PtrLength < u8 >), JsArray < u8 >), interpolate
+		r#macro::wat_indirect!(JsArray < u8 >), interpolate < PtrConst < u8 > as Input > ::WAT_TYPE,
+		interpolate < PtrLength < u8 > as Input > ::WAT_TYPE, interpolate r#macro::wat_direct:: <
+		JsArray < u8 > > (), interpolate r#macro::wat_input!(PtrConst < u8 >), interpolate
+		r#macro::wat_input!(PtrLength < u8 >), interpolate r#macro::wat_output!(JsArray < u8 >),
+	}
+
+	js_bindgen::import_js! {
+		module = "js_sys",
+		name = "array_u8_decode",
+		required_embeds = [
+			("js_sys", "view.getUint8"),
+			r#macro::js_input_embed::<PtrConst<u8>>(),
+			r#macro::js_input_embed::<PtrLength<u8>>(),
+			r#macro::js_output_embed::<JsArray<u8>>(),
+		],
+		"{}{}{}{}",
+		interpolate r#macro::js_select!(
+			"",
+			"(array, len) => {\n",
+			(PtrConst<u8>, PtrLength<u8>),
+			JsArray<u8>,
+		),
+		interpolate r#macro::js_parameter!("array", PtrConst<u8>),
+		interpolate r#macro::js_parameter!("len", PtrLength<u8>),
+		interpolate r#macro::js_output!(
+			"\treturn ",
+			"this.#jsEmbed.js_sys['view.getUint8']",
+			"this.#jsEmbed.js_sys['view.getUint8'](array, len)",
+			JsArray<u8>,
+			PtrConst<u8>,
+			PtrLength<u8>,
+		),
+	}
+
+	unsafe extern "C" {
+		#[link_name = "js_sys.array_u8_decode"]
+		fn array_u8_decode(
+			array: <PtrConst<u8> as Input>::Type,
+			len: <PtrLength<u8> as Input>::Type,
+		) -> <JsArray<u8> as Output>::Type;
+	}
+
+	Output::from_raw(unsafe { array_u8_decode(Input::into_raw(array), Input::into_raw(len)) })
+}
+
+pub(super) unsafe fn array_u8_encode(
+	array: &JsArray<u8>,
+	ptr: PtrMut<u8>,
+	len: PtrLength<u8>,
+) -> bool {
+	js_bindgen::unsafe_global_wat! {
+		"(import \"js_sys\" \"array_u8_encode\" (func $js_sys.import.array_u8_encode (@sym (name \"js_sys.import.array_u8_encode\")) (param {} {} {}) (result {}))){}",
+		"(func $js_sys.array_u8_encode (@sym) (param {}) (param $array {}) (param $ptr {}) (param $len {}) (result {})",
+		"  local.get $array{}", "  local.get $ptr{}", "  local.get $len{}",
+		"  call $js_sys.import.array_u8_encode (@reloc){}", ")", interpolate
+		r#macro::wat_input_import_type:: < & JsArray < u8 > > (), interpolate
+		r#macro::wat_input_import_type:: < PtrMut < u8 > > (), interpolate
+		r#macro::wat_input_import_type:: < PtrLength < u8 > > (), interpolate
+		r#macro::wat_output_import_type:: < bool > (), interpolate r#macro::wat_imports!((& JsArray
+		< u8 >, PtrMut < u8 >, PtrLength < u8 >), bool), interpolate r#macro::wat_indirect!(bool),
+		interpolate < & JsArray < u8 > as Input > ::WAT_TYPE, interpolate < PtrMut < u8 > as Input >
+		::WAT_TYPE, interpolate < PtrLength < u8 > as Input > ::WAT_TYPE, interpolate
+		r#macro::wat_direct:: < bool > (), interpolate r#macro::wat_input!(& JsArray < u8 >),
+		interpolate r#macro::wat_input!(PtrMut < u8 >), interpolate r#macro::wat_input!(PtrLength <
+		u8 >), interpolate r#macro::wat_output!(bool),
+	}
+
+	js_bindgen::import_js! {
+		module = "js_sys",
+		name = "array_u8_encode",
+		required_embeds = [
+			("js_sys", "array.u8.encode"),
+			r#macro::js_input_embed::<&JsArray<u8>>(),
+			r#macro::js_input_embed::<PtrMut<u8>>(),
+			r#macro::js_input_embed::<PtrLength<u8>>(),
+			r#macro::js_output_embed::<bool>(),
+		],
+		"{}{}{}{}{}",
+		interpolate r#macro::js_select!(
+			"",
+			"(array, ptr, len) => {\n",
+			(&JsArray<u8>, PtrMut<u8>, PtrLength<u8>),
+			bool,
+		),
+		interpolate r#macro::js_parameter!("array", &JsArray<u8>),
+		interpolate r#macro::js_parameter!("ptr", PtrMut<u8>),
+		interpolate r#macro::js_parameter!("len", PtrLength<u8>),
+		interpolate r#macro::js_output!(
+			"\treturn ",
+			"this.#jsEmbed.js_sys['array.u8.encode']",
+			"this.#jsEmbed.js_sys['array.u8.encode'](array, ptr, len)",
+			bool,
+			&JsArray<u8>,
+			PtrMut<u8>,
+			PtrLength<u8>,
+		),
+	}
+
+	unsafe extern "C" {
+		#[link_name = "js_sys.array_u8_encode"]
+		fn array_u8_encode(
+			array: <&JsArray<u8> as Input>::Type,
+			ptr: <PtrMut<u8> as Input>::Type,
+			len: <PtrLength<u8> as Input>::Type,
+		) -> <bool as Output>::Type;
+	}
+
+	Output::from_raw(unsafe {
+		array_u8_encode(Input::into_raw(array), Input::into_raw(ptr), Input::into_raw(len))
+	})
+}

--- a/client/js-sys/src/array/array.js-sys.rs
+++ b/client/js-sys/src/array/array.js-sys.rs
@@ -34,4 +34,14 @@ extern "js-sys" {
 		ptr: PtrMut<u32>,
 		len: PtrLength<u32>,
 	) -> bool;
+
+	#[js_sys(js_embed = "view.getUint8")]
+	pub(super) unsafe fn array_u8_decode(array: PtrConst<u8>, len: PtrLength<u8>) -> JsArray<u8>;
+
+	#[js_sys(js_embed = "array.u8.encode")]
+	pub(super) unsafe fn array_u8_encode(
+		array: &JsArray<u8>,
+		ptr: PtrMut<u8>,
+		len: PtrLength<u8>,
+	) -> bool;
 }

--- a/client/js-sys/src/array/mod.rs
+++ b/client/js-sys/src/array/mod.rs
@@ -332,6 +332,108 @@ unsafe impl Input for &[u32] {
 	}
 }
 
+impl JsArray<u8> {
+	pub fn to_slice(&self, slice: &mut [u8]) -> Result<(), TryFromJsArrayError> {
+		// SAFETY: Parameters are correct.
+		let result =
+			unsafe { array::array_u8_encode(self, PtrMut::new(slice), PtrLength::new(slice)) };
+
+		if result {
+			Ok(())
+		} else {
+			Err(TryFromJsArrayError)
+		}
+	}
+
+	pub fn to_uninit_slice<'slice>(
+		&self,
+		slice: &'slice mut [MaybeUninit<u8>],
+	) -> Result<&'slice mut [u8], TryFromJsArrayError> {
+		// SAFETY: Parameters are correct.
+		let result = unsafe {
+			array::array_u8_encode(
+				self,
+				PtrMut::from_uninit_slice(slice),
+				PtrLength::from_uninit_slice(slice),
+			)
+		};
+
+		if result {
+			// SAFETY: Correctly initialized in JS.
+			Ok(unsafe { assume_init_mut(slice) })
+		} else {
+			Err(TryFromJsArrayError)
+		}
+	}
+
+	#[must_use]
+	pub fn to_array<const N: usize>(&self) -> Option<[u8; N]> {
+		let mut array: MaybeUninit<[u8; N]> = MaybeUninit::uninit();
+
+		// SAFETY: Parameters are correct.
+		let result = unsafe {
+			array::array_u8_encode(
+				self,
+				PtrMut::from_uninit_array(&mut array),
+				PtrLength::from_uninit_array(&array),
+			)
+		};
+
+		if result {
+			// SAFETY: Correctly initialized in JS.
+			Some(unsafe { array.assume_init() })
+		} else {
+			None
+		}
+	}
+}
+
+js_bindgen::embed_js!(
+	module = "js_sys",
+	name = "array.u8.encode",
+	required_embeds = [("js_sys", "view.setUint8")],
+	"(array, ptr, len) => {{",
+	"	if (array.length !== len) return false",
+	"",
+	"	this.#jsEmbed.js_sys['view.setUint8'](ptr, array)",
+	"	return true",
+	"}}",
+);
+
+impl From<&[u8]> for JsArray<u8> {
+	fn from(value: &[u8]) -> Self {
+		// SAFETY: Parameters are correct.
+		unsafe { array::array_u8_decode(PtrConst::new(value), PtrLength::new(value)) }
+	}
+}
+
+// SAFETY: Implementation.
+unsafe impl Input for &[u8] {
+	const WAT_TYPE: &'static str = Self::Type::WAT_TYPE;
+	const WAT_CONV: Option<InputWatConv> = Self::Type::WAT_CONV;
+	const JS_CONV: Option<InputJsConv> = Some(InputJsConv {
+		embed: Some(("js_sys", "array.rust.u8")),
+		pre: " = this.#jsEmbed.js_sys['array.rust.u8'](",
+		post: Some(")"),
+	});
+
+	type Type = ExternSlice<u8>;
+
+	fn into_raw(self) -> Self::Type {
+		js_bindgen::embed_js!(
+			module = "js_sys",
+			name = "array.rust.u8",
+			required_embeds = [("js_sys", "extern_ref"), ("js_sys", "view.getUint8")],
+			"(dataPtr) => {{",
+			"	const {{ ptr, len }} = this.#jsEmbed.js_sys.extern_ref(dataPtr)",
+			"	return this.#jsEmbed.js_sys['view.getUint8'](ptr, len)",
+			"}}",
+		);
+
+		ExternSlice::new(self)
+	}
+}
+
 // MSRV: Stable on v1.93.
 const unsafe fn assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
 	// SAFETY: copied from Std.

--- a/client/js-sys/src/util.rs
+++ b/client/js-sys/src/util.rs
@@ -464,6 +464,7 @@ macro_rules! buffer {
 	};
 }
 
+buffer!("Uint8", 1_usize);
 buffer!("Uint32", 4_usize);
 buffer!("Int32", 4_usize);
 buffer!("Float64", 8_usize);

--- a/client/js-sys/tests/array.rs
+++ b/client/js-sys/tests/array.rs
@@ -28,6 +28,28 @@ fn js_value() {
 }
 
 #[test]
+fn u8() {
+	#[js_sys]
+	extern "js-sys" {
+		#[js_sys(js_embed = "test")]
+		fn u8(value: &[u8]) -> JsArray<u8>;
+	}
+
+	let rust_array: [u8; 42] = array::from_fn(|i| i.try_into().unwrap());
+	let js_array = JsArray::from(&rust_array);
+	assert_eq!(rust_array.len(), js_array.length().try_into().unwrap());
+
+	let ffi_array = u8(&rust_array);
+	assert_eq!(rust_array.len(), ffi_array.length().try_into().unwrap());
+
+	let returned_array: [u8; 42] = js_array.to_array().unwrap();
+	assert_eq!(rust_array, returned_array);
+
+	let returned_array: [u8; 42] = ffi_array.to_array().unwrap();
+	assert_eq!(rust_array, returned_array);
+}
+
+#[test]
 fn u32() {
 	#[js_sys]
 	extern "js-sys" {

--- a/client/test/Cargo.toml
+++ b/client/test/Cargo.toml
@@ -14,5 +14,8 @@ test = false
 js-bindgen-test-macro = { workspace = true }
 js-sys = { workspace = true, features = ["macro"] }
 
+[target.'cfg(js_bindgen_cov)'.dependencies]
+js-bindgen-cov = { workspace = true }
+
 [lints]
 workspace = true

--- a/client/test/src/lib.rs
+++ b/client/test/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(js_bindgen_cov)]
+js_bindgen_cov::ensure_linked!();
+
 #[cfg(all(target_family = "wasm", any(target_os = "none", target_os = "unknown")))]
 mod unknown;
 

--- a/host/runner/src/js/deno/deno.mjs
+++ b/host/runner/src/js/deno/deno.mjs
@@ -1,6 +1,11 @@
 import { run } from "../shared/shared.mjs";
 import { colorText } from "../shared/shared-terminal.mjs";
 import { JsBindgen } from "../imports.mjs";
+const fs = {
+    writeFile(path, data) {
+        Deno.writeFileSync(path, data);
+    },
+};
 const module = await WebAssembly.compileStreaming(fetch(new URL("../wasm.wasm", import.meta.url)));
 const status = await run(module, JsBindgen, (stream, text) => {
     function printSync(input, to) {
@@ -18,5 +23,5 @@ const status = await run(module, JsBindgen, (stream, text) => {
         case 1 /* Stream.Stderr */:
             printSync(output, Deno.stderr);
     }
-});
+}, fs);
 Deno.exit(status);

--- a/host/runner/src/js/deno/deno.mts
+++ b/host/runner/src/js/deno/deno.mts
@@ -1,28 +1,39 @@
-import { run, Stream } from "../shared/shared.mjs"
+import { type FsBackend, run, Stream } from "../shared/shared.mjs"
 import { colorText } from "../shared/shared-terminal.mjs"
 import { JsBindgen } from "../imports.mts"
 
+const fs: FsBackend = {
+	writeFile(path, data) {
+		Deno.writeFileSync(path, data)
+	},
+}
+
 const module = await WebAssembly.compileStreaming(fetch(new URL("../wasm.wasm", import.meta.url)))
 
-const status = await run(module, JsBindgen, (stream, text) => {
-	function printSync(input: string, to: typeof Deno.stdout | typeof Deno.stderr) {
-		let bytesWritten = 0
-		const bytes = new TextEncoder().encode(input)
+const status = await run(
+	module,
+	JsBindgen,
+	(stream, text) => {
+		function printSync(input: string, to: typeof Deno.stdout | typeof Deno.stderr) {
+			let bytesWritten = 0
+			const bytes = new TextEncoder().encode(input)
 
-		while (bytesWritten < bytes.length) {
-			bytesWritten += to.writeSync(bytes.subarray(bytesWritten))
+			while (bytesWritten < bytes.length) {
+				bytesWritten += to.writeSync(bytes.subarray(bytesWritten))
+			}
 		}
-	}
 
-	const output = colorText(text)
+		const output = colorText(text)
 
-	switch (stream) {
-		case Stream.Stdout:
-			printSync(output, Deno.stdout)
-			break
-		case Stream.Stderr:
-			printSync(output, Deno.stderr)
-	}
-})
+		switch (stream) {
+			case Stream.Stdout:
+				printSync(output, Deno.stdout)
+				break
+			case Stream.Stderr:
+				printSync(output, Deno.stderr)
+		}
+	},
+	fs
+)
 
 Deno.exit(status)

--- a/host/runner/src/js/dom/server.mjs
+++ b/host/runner/src/js/dom/server.mjs
@@ -1,4 +1,4 @@
-import { run } from "../shared/shared.mjs";
+import { createBrowserFsBackend, run } from "../shared/shared.mjs";
 import { toOutput } from "./shared-server.mjs";
 import { importJsBindgen } from "../shared/shared-import.mjs";
 const module = await WebAssembly.compileStreaming(fetch("../wasm.wasm"));
@@ -7,7 +7,9 @@ if (jsBindgenCtor instanceof Error) {
     toOutput([{ text: jsBindgenCtor.message + "\n", color: 0 /* Color.Default */ }]);
 }
 else {
+    const fs = createBrowserFsBackend();
     await run(module, jsBindgenCtor, (_, text) => {
         toOutput(text);
-    });
+    }, fs);
+    await fs.flush();
 }

--- a/host/runner/src/js/dom/server.mts
+++ b/host/runner/src/js/dom/server.mts
@@ -1,4 +1,4 @@
-import { Color, run } from "../shared/shared.mjs"
+import { Color, createBrowserFsBackend, run } from "../shared/shared.mjs"
 import { toOutput } from "./shared-server.mts"
 import { importJsBindgen } from "../shared/shared-import.mjs"
 
@@ -8,7 +8,14 @@ const jsBindgenCtor = await importJsBindgen()
 if (jsBindgenCtor instanceof Error) {
 	toOutput([{ text: jsBindgenCtor.message + "\n", color: Color.Default }])
 } else {
-	await run(module, jsBindgenCtor, (_, text) => {
-		toOutput(text)
-	})
+	const fs = createBrowserFsBackend()
+	await run(
+		module,
+		jsBindgenCtor,
+		(_, text) => {
+			toOutput(text)
+		},
+		fs
+	)
+	await fs.flush()
 }

--- a/host/runner/src/js/node-js/node-js.mjs
+++ b/host/runner/src/js/node-js/node-js.mjs
@@ -1,7 +1,13 @@
 import { open } from "node:fs/promises";
+import { writeFileSync } from "node:fs";
 import { run } from "../shared/shared.mjs";
 import { colorText } from "../shared/shared-terminal.mjs";
 import { JsBindgen } from "../imports.mjs";
+const fs = {
+    writeFile(path, data) {
+        writeFileSync(path, data);
+    },
+};
 const wasmFile = await open(new URL("../wasm.wasm", import.meta.url));
 const wasmResponse = new Response(
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
@@ -18,5 +24,5 @@ const status = await run(module, JsBindgen, (stream, text) => {
         case 1 /* Stream.Stderr */:
             process.stderr.write(output);
     }
-});
+}, fs);
 process.exit(status);

--- a/host/runner/src/js/node-js/node-js.mts
+++ b/host/runner/src/js/node-js/node-js.mts
@@ -1,7 +1,14 @@
 import { open } from "node:fs/promises"
-import { Stream, run } from "../shared/shared.mjs"
+import { writeFileSync } from "node:fs"
+import { Stream, type FsBackend, run } from "../shared/shared.mjs"
 import { colorText } from "../shared/shared-terminal.mjs"
 import { JsBindgen } from "../imports.mts"
+
+const fs: FsBackend = {
+	writeFile(path, data) {
+		writeFileSync(path, data)
+	},
+}
 
 const wasmFile = await open(new URL("../wasm.wasm", import.meta.url))
 const wasmResponse = new Response(
@@ -13,16 +20,21 @@ const wasmResponse = new Response(
 )
 const module = await WebAssembly.compileStreaming(wasmResponse)
 
-const status = await run(module, JsBindgen, (stream, text) => {
-	const output = colorText(text)
+const status = await run(
+	module,
+	JsBindgen,
+	(stream, text) => {
+		const output = colorText(text)
 
-	switch (stream) {
-		case Stream.Stdout:
-			process.stdout.write(output)
-			break
-		case Stream.Stderr:
-			process.stderr.write(output)
-	}
-})
+		switch (stream) {
+			case Stream.Stdout:
+				process.stdout.write(output)
+				break
+			case Stream.Stderr:
+				process.stderr.write(output)
+		}
+	},
+	fs
+)
 
 process.exit(status)

--- a/host/runner/src/js/run-data.d.json.ts
+++ b/host/runner/src/js/run-data.d.json.ts
@@ -3,6 +3,7 @@ type RunData = TestRunData | BinaryRunData
 type TestRunData = {
 	kind: "test"
 	worker: WorkerKind
+	ctx: Ctx
 	noCapture: boolean
 	filteredCount: number
 	tests: TestEntry[]
@@ -11,6 +12,7 @@ type TestRunData = {
 type BinaryRunData = {
 	kind: "binary"
 	worker: WorkerKind
+	ctx: Ctx
 	wasm64: boolean
 	memory: MainMemory
 	args: string[]
@@ -32,6 +34,12 @@ type TestEntry = {
 type MainMemory = {
 	module: string
 	name: string
+}
+
+type Ctx = {
+	pid: number
+	tmpdir: string
+	llvm_profile_file?: string
 }
 
 declare const config: RunData

--- a/host/runner/src/js/shared/shared-browser.mjs
+++ b/host/runner/src/js/shared/shared-browser.mjs
@@ -1,4 +1,4 @@
-import { run } from "./shared.mjs";
+import { createBrowserFsBackend, run } from "./shared.mjs";
 import { colorText } from "./shared-terminal.mjs";
 export async function runBrowser(jsBindgenCtor) {
     let fetchOrder = 0;
@@ -38,10 +38,12 @@ export async function runBrowser(jsBindgenCtor) {
         status = 1 /* Status.Abnormal */;
     }
     else {
-        status = await WebAssembly.compileStreaming(fetch("../wasm.wasm")).then(module => run(module, jsBindgenCtor, (stream, text) => report(stream, colorText(text))), (error) => {
+        const fs = createBrowserFsBackend();
+        status = await WebAssembly.compileStreaming(fetch("../wasm.wasm")).then(module => run(module, jsBindgenCtor, (stream, text) => report(stream, colorText(text)), fs), (error) => {
             report(1 /* Stream.Stderr */, error.message + "\n");
             return 1 /* Status.Abnormal */;
         });
+        await fs.flush();
     }
     if (fetchRunning !== 0) {
         fetchWaiting = true;

--- a/host/runner/src/js/shared/shared-browser.mts
+++ b/host/runner/src/js/shared/shared-browser.mts
@@ -1,4 +1,4 @@
-import { Stream, Status, run } from "./shared.mts"
+import { Stream, Status, createBrowserFsBackend, run } from "./shared.mts"
 import { colorText } from "./shared-terminal.mts"
 import type { JsBindgen } from "../imports.mts"
 
@@ -44,14 +44,17 @@ export async function runBrowser(jsBindgenCtor: typeof JsBindgen | Error) {
 		report(Stream.Stderr, jsBindgenCtor.message + "\n")
 		status = Status.Abnormal
 	} else {
+		const fs = createBrowserFsBackend()
 		status = await WebAssembly.compileStreaming(fetch("../wasm.wasm")).then(
-			module => run(module, jsBindgenCtor, (stream, text) => report(stream, colorText(text))),
+			module => run(module, jsBindgenCtor, (stream, text) => report(stream, colorText(text)), fs),
 			(error: unknown) => {
 				report(Stream.Stderr, (error as Error).message + "\n")
 
 				return Status.Abnormal
 			}
 		)
+
+		await fs.flush()
 	}
 
 	if (fetchRunning !== 0) {

--- a/host/runner/src/js/shared/shared.mjs
+++ b/host/runner/src/js/shared/shared.mjs
@@ -1,4 +1,27 @@
 import runData from "../run-data.json" with { type: "json" };
+export function createBrowserFsBackend() {
+    const writes = new Map();
+    return {
+        writeFile(path, data) {
+            writes.set(path, data);
+        },
+        async flush() {
+            for (const [path, data] of writes) {
+                const result = await fetch("../fs/write", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/octet-stream",
+                        "X-Js-Bindgen-Path": path,
+                    },
+                    body: data.slice(),
+                });
+                if (!result.ok) {
+                    throw new Error(`fetch failed with status ${result.status}`);
+                }
+            }
+        },
+    };
+}
 function mainMemory(module, name, importObject) {
     const value = importObject[module]?.[name];
     if (!(value instanceof WebAssembly.Memory)) {
@@ -45,12 +68,15 @@ function mainArgs(memory, values, wasm64) {
         return { argc: args.length, argv: ptr };
     }
 }
-export async function run(module, jsBindgenCtor, report) {
+export async function run(module, jsBindgenCtor, report, fs) {
     let interceptFlag = false;
     const interceptStore = [];
     const newLineText = { text: "\n", color: 0 /* Color.Default */ };
     const failedText = { text: "FAILED", color: 3 /* Color.Red */ };
     const okText = { text: "ok", color: 1 /* Color.Green */ };
+    const ctx = runData.ctx;
+    let profraw;
+    let profrawPath;
     const CONSOLE_METHODS = ["debug", "log", "info", "warn", "error"];
     CONSOLE_METHODS.forEach(level => {
         const origin = console[level].bind(console);
@@ -89,6 +115,17 @@ export async function run(module, jsBindgenCtor, report) {
                 set_message: (message) => (panicMessage = message),
                 set_payload: (payload) => (panicPayload = payload),
             },
+            js_bindgen_cov: {
+                pid: () => ctx.pid,
+                tmpdir: () => ctx.tmpdir,
+                llvm_profile_file: () => ctx.llvm_profile_file ?? "",
+                next_profraw: () => profraw ?? new Uint8Array(),
+                record_profraw: (path, data) => {
+                    const bytes = Uint8Array.from(data);
+                    profraw = bytes;
+                    profrawPath = path;
+                },
+            },
         });
         const importObject = jsBindgen.importObject;
         const instance = await jsBindgen.instantiate();
@@ -102,6 +139,17 @@ export async function run(module, jsBindgenCtor, report) {
                 return panicPayload;
             },
         };
+    }
+    function captureProfraw(state) {
+        const f = state.instance.exports["set_profraw"];
+        if (f) {
+            f();
+        }
+    }
+    function flushProfraw() {
+        if (profrawPath && profraw) {
+            fs.writeFile(profrawPath, profraw);
+        }
     }
     if (runData.kind === "binary") {
         const state = await instantiate();
@@ -132,6 +180,8 @@ export async function run(module, jsBindgenCtor, report) {
         finally {
             interceptFlag = false;
         }
+        captureProfraw(state);
+        flushProfraw();
         return status;
     }
     const startTime = performance.now();
@@ -177,6 +227,7 @@ export async function run(module, jsBindgenCtor, report) {
         interceptFlag = true;
         try {
             testFn();
+            captureProfraw(state);
             result = { success: true };
         }
         catch (error) {
@@ -233,6 +284,7 @@ export async function run(module, jsBindgenCtor, report) {
             });
         }
     }
+    flushProfraw();
     let output1 = "\n";
     if (failures.length > 0) {
         output1 += "failures:\n\n";

--- a/host/runner/src/js/shared/shared.mts
+++ b/host/runner/src/js/shared/shared.mts
@@ -22,6 +22,41 @@ export const enum Status {
 	Abnormal = 1,
 }
 
+export type FsBackend = {
+	writeFile(path: string, data: Uint8Array): void
+	flush?(): Promise<void>
+}
+
+export type FlushableFsBackend = FsBackend & {
+	flush(): Promise<void>
+}
+
+export function createBrowserFsBackend(): FlushableFsBackend {
+	const writes = new Map<string, Uint8Array>()
+
+	return {
+		writeFile(path, data) {
+			writes.set(path, data)
+		},
+		async flush() {
+			for (const [path, data] of writes) {
+				const result = await fetch("../fs/write", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/octet-stream",
+						"X-Js-Bindgen-Path": path,
+					},
+					body: data.slice(),
+				})
+
+				if (!result.ok) {
+					throw new Error(`fetch failed with status ${result.status}`)
+				}
+			}
+		},
+	}
+}
+
 type MainArgs32 = { argc: number; argv: number }
 type MainArgs64 = { argc: number; argv: bigint }
 
@@ -93,13 +128,17 @@ function mainArgs(
 export async function run(
 	module: WebAssembly.Module,
 	jsBindgenCtor: typeof JsBindgen,
-	report: (stream: Stream, text: StyledText[]) => void
+	report: (stream: Stream, text: StyledText[]) => void,
+	fs: FsBackend
 ): Promise<number> {
 	let interceptFlag = false
 	const interceptStore: string[] = []
 	const newLineText = { text: "\n", color: Color.Default }
 	const failedText = { text: "FAILED", color: Color.Red }
 	const okText = { text: "ok", color: Color.Green }
+	const ctx = runData.ctx
+	let profraw: Uint8Array | undefined
+	let profrawPath: string | undefined
 
 	const CONSOLE_METHODS = ["debug", "log", "info", "warn", "error"] as const
 	CONSOLE_METHODS.forEach(level => {
@@ -141,6 +180,17 @@ export async function run(
 				set_message: (message: string) => (panicMessage = message),
 				set_payload: (payload: string) => (panicPayload = payload),
 			},
+			js_bindgen_cov: {
+				pid: () => ctx.pid,
+				tmpdir: () => ctx.tmpdir,
+				llvm_profile_file: () => ctx.llvm_profile_file ?? "",
+				next_profraw: () => profraw ?? new Uint8Array(),
+				record_profraw: (path: string, data: ArrayLike<number>) => {
+					const bytes = Uint8Array.from(data)
+					profraw = bytes
+					profrawPath = path
+				},
+			},
 		})
 
 		const importObject = jsBindgen.importObject
@@ -155,6 +205,19 @@ export async function run(
 			get panicPayload() {
 				return panicPayload
 			},
+		}
+	}
+
+	function captureProfraw(state: { instance: WebAssembly.Instance }) {
+		const f = state.instance.exports["set_profraw"] as (() => void) | undefined
+		if (f) {
+			f()
+		}
+	}
+
+	function flushProfraw() {
+		if (profrawPath && profraw) {
+			fs.writeFile(profrawPath, profraw)
 		}
 	}
 
@@ -189,6 +252,9 @@ export async function run(
 		} finally {
 			interceptFlag = false
 		}
+
+		captureProfraw(state)
+		flushProfraw()
 
 		return status
 	}
@@ -245,6 +311,7 @@ export async function run(
 
 		try {
 			testFn()
+			captureProfraw(state)
 			result = { success: true }
 		} catch (error) {
 			result = {
@@ -310,6 +377,8 @@ export async function run(
 			})
 		}
 	}
+
+	flushProfraw()
 
 	let output1 = "\n"
 

--- a/host/runner/src/js/worker/server-dedicated.mjs
+++ b/host/runner/src/js/worker/server-dedicated.mjs
@@ -1,4 +1,4 @@
-import { run } from "../shared/shared.mjs";
+import { createBrowserFsBackend, run } from "../shared/shared.mjs";
 import { importJsBindgen } from "../shared/shared-import.mjs";
 const module = await WebAssembly.compileStreaming(fetch("../wasm.wasm"));
 const jsBindgenCtor = await importJsBindgen();
@@ -6,8 +6,10 @@ if (jsBindgenCtor instanceof Error) {
     self.postMessage(jsBindgenCtor.message + "\n");
 }
 else {
+    const fs = createBrowserFsBackend();
     await run(module, jsBindgenCtor, (_, text) => {
         self.postMessage(text);
-    });
+    }, fs);
+    await fs.flush();
 }
 self.close();

--- a/host/runner/src/js/worker/server-dedicated.mts
+++ b/host/runner/src/js/worker/server-dedicated.mts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-var
 declare var self: DedicatedWorkerGlobalScope
 
-import { run } from "../shared/shared.mjs"
+import { createBrowserFsBackend, run } from "../shared/shared.mjs"
 import { importJsBindgen } from "../shared/shared-import.mjs"
 
 const module = await WebAssembly.compileStreaming(fetch("../wasm.wasm"))
@@ -10,9 +10,16 @@ const jsBindgenCtor = await importJsBindgen()
 if (jsBindgenCtor instanceof Error) {
 	self.postMessage(jsBindgenCtor.message + "\n")
 } else {
-	await run(module, jsBindgenCtor, (_, text) => {
-		self.postMessage(text)
-	})
+	const fs = createBrowserFsBackend()
+	await run(
+		module,
+		jsBindgenCtor,
+		(_, text) => {
+			self.postMessage(text)
+		},
+		fs
+	)
+	await fs.flush()
 }
 
 self.close()

--- a/host/runner/src/js/worker/server-service.mjs
+++ b/host/runner/src/js/worker/server-service.mjs
@@ -1,8 +1,10 @@
-import { run } from "../shared/shared.mjs";
+import { createBrowserFsBackend, run } from "../shared/shared.mjs";
 import { JsBindgen } from "../imports.mjs";
 self.addEventListener("message", async (event) => {
     const module = await WebAssembly.compileStreaming(fetch("../wasm.wasm"));
     const [port] = event.ports;
-    await run(module, JsBindgen, (_, text) => port.postMessage(text));
+    const fs = createBrowserFsBackend();
+    await run(module, JsBindgen, (_, text) => port.postMessage(text), fs);
+    await fs.flush();
     await self.registration.unregister();
 });

--- a/host/runner/src/js/worker/server-service.mts
+++ b/host/runner/src/js/worker/server-service.mts
@@ -1,14 +1,16 @@
 // eslint-disable-next-line no-var
 declare var self: ServiceWorkerGlobalScope
 
-import { run } from "../shared/shared.mjs"
+import { createBrowserFsBackend, run } from "../shared/shared.mjs"
 import { JsBindgen } from "../imports.mts"
 
 self.addEventListener("message", async event => {
 	const module = await WebAssembly.compileStreaming(fetch("../wasm.wasm"))
 	const [port] = event.ports
+	const fs = createBrowserFsBackend()
 
-	await run(module, JsBindgen, (_, text) => port!.postMessage(text))
+	await run(module, JsBindgen, (_, text) => port!.postMessage(text), fs)
+	await fs.flush()
 
 	await self.registration.unregister()
 })

--- a/host/runner/src/js/worker/server-shared.mjs
+++ b/host/runner/src/js/worker/server-shared.mjs
@@ -1,4 +1,4 @@
-import { run } from "../shared/shared.mjs";
+import { createBrowserFsBackend, run } from "../shared/shared.mjs";
 import { importJsBindgen } from "../shared/shared-import.mjs";
 self.addEventListener("connect", async (event) => {
     const module = await WebAssembly.compileStreaming(fetch("../wasm.wasm"));
@@ -8,9 +8,11 @@ self.addEventListener("connect", async (event) => {
         port.postMessage(jsBindgenCtor.message + "\n");
     }
     else {
+        const fs = createBrowserFsBackend();
         await run(module, jsBindgenCtor, (_, text) => {
             port.postMessage(text);
-        });
+        }, fs);
+        await fs.flush();
     }
     self.close();
 });

--- a/host/runner/src/js/worker/server-shared.mts
+++ b/host/runner/src/js/worker/server-shared.mts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-var
 declare var self: SharedWorkerGlobalScope
 
-import { run } from "../shared/shared.mjs"
+import { createBrowserFsBackend, run } from "../shared/shared.mjs"
 import { importJsBindgen } from "../shared/shared-import.mjs"
 
 self.addEventListener("connect", async event => {
@@ -13,9 +13,16 @@ self.addEventListener("connect", async event => {
 	if (jsBindgenCtor instanceof Error) {
 		port.postMessage(jsBindgenCtor.message + "\n")
 	} else {
-		await run(module, jsBindgenCtor, (_, text) => {
-			port.postMessage(text)
-		})
+		const fs = createBrowserFsBackend()
+		await run(
+			module,
+			jsBindgenCtor,
+			(_, text) => {
+				port.postMessage(text)
+			},
+			fs
+		)
+		await fs.flush()
 	}
 
 	self.close()

--- a/host/runner/src/main.rs
+++ b/host/runner/src/main.rs
@@ -12,7 +12,7 @@ use js_bindgen_cli_lib::{JS_OUTPUT_SECTION, JsOutput};
 use js_bindgen_shared::{IS_COMPAT_SECTION, ReadFile};
 use wasmparser::{MemoryType, Parser, Payload, TypeRef};
 
-use crate::run_data::RunData;
+use crate::run_data::{Ctx, RunData};
 use crate::runner::Runner;
 use crate::test::{TestCli, TestParser};
 
@@ -102,6 +102,7 @@ fn main() -> Result<()> {
 		};
 
 		Some(RunData::Binary {
+			ctx: Ctx::new(),
 			wasm64: main_memory.data.memory64,
 			memory: js_output.main_memory,
 			args,

--- a/host/runner/src/run_data.rs
+++ b/host/runner/src/run_data.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::{env, process};
+
 use js_bindgen_cli_lib::MainMemory;
 use serde::Serialize;
 
@@ -11,13 +14,33 @@ use crate::test::TestEntry;
 )]
 pub enum RunData<'a> {
 	Test {
+		ctx: Ctx,
 		no_capture: bool,
 		filtered_count: usize,
 		tests: Vec<TestEntry<'a>>,
 	},
 	Binary {
+		ctx: Ctx,
 		wasm64: bool,
 		memory: MainMemory<'a>,
 		args: Vec<String>,
 	},
+}
+
+#[derive(Serialize)]
+pub struct Ctx {
+	pid: u32,
+	tmpdir: PathBuf,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	llvm_profile_file: Option<String>,
+}
+
+impl Ctx {
+	pub fn new() -> Self {
+		Self {
+			pid: process::id(),
+			tmpdir: env::temp_dir(),
+			llvm_profile_file: env::var("LLVM_PROFILE_FILE").ok(),
+		}
+	}
 }

--- a/host/runner/src/runner.rs
+++ b/host/runner/src/runner.rs
@@ -79,6 +79,7 @@ impl Runner {
 			.arg("run")
 			.args(args)
 			.arg("--allow-read")
+			.arg("--allow-write")
 			.arg(script_path)
 			.status()?;
 

--- a/host/runner/src/server.rs
+++ b/host/runner/src/server.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fs;
 use std::io::{self, ErrorKind, Write};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::ops::DerefMut;
@@ -6,10 +7,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use anyhow::{Context, Result};
-use axum::body::Body;
+use axum::body::{Body, Bytes};
 use axum::extract::State;
-use axum::http::HeaderValue;
 use axum::http::header::CONTENT_TYPE;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::Response;
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -158,6 +159,30 @@ impl HttpServer {
 				get(async |State(state): State<Arc<ServerState>>| {
 					response("application/javascript", state.js_output.clone())
 				}),
+			)
+			.route(
+				"/fs/write",
+				post(
+					async |headers: HeaderMap, body: Bytes| -> Result<(), (StatusCode, String)> {
+						let path = headers
+							.get("x-js-bindgen-path")
+							.ok_or_else(|| {
+								(
+									StatusCode::BAD_REQUEST,
+									"missing `X-Js-Bindgen-Path` header".to_owned(),
+								)
+							})?
+							.to_str()
+							.map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))?;
+
+						fs::write(path, body).map_err(|error| {
+							(
+								StatusCode::INTERNAL_SERVER_ERROR,
+								format!("failed to write `{path}`: {error}"),
+							)
+						})
+					},
+				),
 			);
 
 		if worker.is_some() {
@@ -350,7 +375,7 @@ fn response(content_type: &'static str, body: impl Into<Body>) -> Response {
 	);
 	headers.insert(
 		"Access-Control-Allow-Headers",
-		HeaderValue::from_static("Content-Type"),
+		HeaderValue::from_static("Content-Type, X-Js-Bindgen-Path"),
 	);
 	headers.insert(
 		"Cross-Origin-Opener-Policy",

--- a/host/runner/src/test.rs
+++ b/host/runner/src/test.rs
@@ -6,7 +6,7 @@ use js_bindgen_shared::IS_TEST_SECTION;
 use serde::{Serialize, Serializer};
 use wasmparser::Payload;
 
-use crate::run_data::RunData;
+use crate::run_data::{Ctx, RunData};
 
 #[derive(Parser)]
 #[command(name = "js-bindgen-runner", version, about, long_about = None)]
@@ -212,6 +212,7 @@ impl TestCli {
 		}
 
 		Some(RunData::Test {
+			ctx: Ctx::new(),
 			no_capture: cli.no_capture,
 			filtered_count,
 			tests,


### PR DESCRIPTION
Do we need to implement `js-bindgen-cov` directly inside `js-bindgen-test`? My main concern is how custom targets would use it. 

And for custom targets, how can we ensure they are linked to `minicov`? In other words, how should we handle the `ensure_linked!` workaround. The best approach would be to customize `library/profiler_builtins`, but there doesn’t seem to be any precedent for that.

Upstream:

1. For wasm64 coverage to work correctly, we need to wait for LLVM to release a new version: https://github.com/llvm/llvm-project/pull/204055

2. To make `llvm-cov` able to report on workspace, need to: https://github.com/taiki-e/cargo-llvm-cov/pull/500